### PR TITLE
docs: update contribute and code of conduct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the source files for the documentation on the [Appsody website](https://apps
 
 ## Contributing
 
-We welcome all contributions to the Appsody project. Please see our [Contributing guidelines](CONTRIBUTING.md)
+We welcome all contributions to the Appsody project. Please see our [Contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md)
 
 If you find a bug, such as a typo, or are confused by our documentation, please let us know by [creating an issue](https://github.com/appsody/docs/issues/new).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ No project is complete without a nice new CLI to play with. The Appsody CLI is p
 
 ## Contributing
 
-We welcome all contributions, see [CONTRIBUTING](../CONTRIBUTING) and come chat to us in [Slack](if you'd like to get involved).
+We welcome all contributions, see [CONTRIBUTING](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and come chat to us in [Slack](if you'd like to get involved).
 
 Want to see your framework available as an Appsody Stack? See [Link](here) and join the #content-providers channel on the above Slack to introduce yourself!
 

--- a/docs/stacks/create-or-modify.md
+++ b/docs/stacks/create-or-modify.md
@@ -10,7 +10,7 @@ section: Appsody Stacks
 
 You might want to modify an existing stack to suit your development needs, for example you might want to use a different library or runtime version from an existing stack. We are actively working to create new stacks so that more people can adopt Appsody. If you find that none of the existing stacks meet your needs please reach out to us on the [Appsody Slack](https://appsody-slack.eu-gb.mybluemix.net/) or create a new GitHub issue to track the discussion.
 
-We always welcome any contributions. If you want to [create](/docs/stacks/stack-structure.md) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/appsody/docs/blob/master/CODE_OF_CONDUCT.md).
+We always welcome any contributions. If you want to [create](#Creating-a-stack) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/appsody/docs/blob/master/CODE_OF_CONDUCT.md).
 
 Use the following examples to help you get started creating, or modifying stacks. Stacks contain specific files laid out in a particular directory tree, you can learn more about these in our [Structure of a stack](stack-structure.md) guide. This knowledge will be helpful if you'd like to create or modify stacks.
 

--- a/docs/stacks/create-or-modify.md
+++ b/docs/stacks/create-or-modify.md
@@ -5,9 +5,12 @@ section: Appsody Stacks
 ---
 # Creating and Modifying Stacks
 
+
+
+
 You might want to modify an existing stack to suit your development needs, for example you might want to use a different library or runtime version from an existing stack. We are actively working to create new stacks so that more people can adopt Appsody. If you find that none of the existing stacks meet your needs please reach out to us on the [Appsody Slack](https://appsody-slack.eu-gb.mybluemix.net/) or create a new GitHub issue to track the discussion.
 
-We always welcome any contributions. If you want to [create](#Creating-a-stack) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/appsody/docs/blob/master/CODE_OF_CONDUCT.md).
+We always welcome any contributions. If you want to [create](/docs/stacks/stack-structure.md) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/appsody/docs/blob/master/CODE_OF_CONDUCT.md).
 
 Use the following examples to help you get started creating, or modifying stacks. Stacks contain specific files laid out in a particular directory tree, you can learn more about these in our [Structure of a stack](stack-structure.md) guide. This knowledge will be helpful if you'd like to create or modify stacks.
 

--- a/docs/stacks/create-or-modify.md
+++ b/docs/stacks/create-or-modify.md
@@ -7,7 +7,7 @@ section: Appsody Stacks
 
 You might want to modify an existing stack to suit your development needs, for example you might want to use a different library or runtime version from an existing stack. We are actively working to create new stacks so that more people can adopt Appsody. If you find that none of the existing stacks meet your needs please reach out to us on the [Appsody Slack](https://appsody-slack.eu-gb.mybluemix.net/) or create a new GitHub issue to track the discussion.
 
-We always welcome any contributions. If you want to [create](#Creating-a-stack) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE-OF-CONDUCT.md).
+We always welcome any contributions. If you want to [create](#Creating-a-stack) or [modify](#Modifying-a-stack) a stack, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/appsody/docs/blob/master/CODE_OF_CONDUCT.md).
 
 Use the following examples to help you get started creating, or modifying stacks. Stacks contain specific files laid out in a particular directory tree, you can learn more about these in our [Structure of a stack](stack-structure.md) guide. This knowledge will be helpful if you'd like to create or modify stacks.
 

--- a/docs/stacks/stacks-overview.md
+++ b/docs/stacks/stacks-overview.md
@@ -37,7 +37,7 @@ To learn how to go about modifying an existing stack go to [modifying a stack](c
 ## Creating new stacks
 We are actively working to create new stacks so that more people can adopt Appsody. If you find that none of the existing stacks meet your needs please reach out to us on the [Appsody slack]() or create a new GitHub issue to track the discussion.
 
-We always welcome any contributions. If you wanted to create your own stack for a framework or language that we do not currently support, please review the [contributing guidelines](../../CONTRIBUTING.md) and follow the steps outlined in [creating a stack](create-or-modify.md#creating-a-stack).
+We always welcome any contributions. If you wanted to create your own stack for a framework or language that we do not currently support, please review the [contributing guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md) and follow the steps outlined in [creating a stack](create-or-modify.md#creating-a-stack).
 
 ## Need help?
 If you have a question that you can't find an answer to, we would also like to hear about that too. You can reach out to the community for assistance on [Slack]().


### PR DESCRIPTION
Everything outside of the docs folder will *NOT* be rendered on the website atm so changing the links to reference the CONTRIBUTING guidelines to link to github for now
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

For more information on contributing to the Appsody Docs, see the contributing guidelines:
https://github.com/docs/CONTRIBUTING.md
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
