### PR TITLE
doc: add command for adding to docker group

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,7 +44,10 @@ To remove Appsody, run `brew uninstall appsody`. You may also want to remove the
 
 Ensure the [prerequisites](#Prerequisites) are met.
 
-You should also make sure that **your user is a member of the `docker` group**. This is necessary for Appsody to run correctly.
+You should also make sure that **your user is a member of the `docker` group**. This is necessary for Appsody to run correctly. You can do this by executing the following command after substituting in your user for XXXX:
+```
+sudo usermod -aG docker XXXX
+```
 
 To install Appsody on your system follow these steps:
 1) Download the latest **Debian install package** from the [Appsody releases page](https://github.com/appsody/appsody/releases). The file is named `appsody_v.r.m_amd64.deb`, where `v.r.m` indicates the release tag.


### PR DESCRIPTION
Add the specific command to the ubuntu instructions
for adding the user to the docker group. Otherwise
people are left to go google for something we can
easily cover as part of the instructions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

For more information on contributing to the Appsody Docs, see the contributing guidelines:
https://github.com/docs/CONTRIBUTING.md
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [X] commit message follows [commit guidelines](https://github.com/appsody/docs/blob/master/CONTRIBUTING.md#commit-message-guidelines)

Fixes N/A